### PR TITLE
fix: resolve language pack conflict with react-vant base.d.ts

### DIFF
--- a/packages/react-vant/src/components/locale/lang/fr-FR.ts
+++ b/packages/react-vant/src/components/locale/lang/fr-FR.ts
@@ -13,6 +13,7 @@ export default {
     end: 'Fin',
     start: 'Début',
     title: 'Calendrier',
+    confirm: 'Confirmer',
     startEnd: 'Début/Fin',
     weekdays: ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'],
     monthTitle: (year: number, month: number) => `${year}/${month}`,


### PR DESCRIPTION
解决fr语言包文件，缺失了comfirm字段导致和 node_modules/react-vant/es/locale/lang/base.d.ts 定义类型冲突